### PR TITLE
route for logs and close election without votes

### DIFF
--- a/app/psifos/model/crud.py
+++ b/app/psifos/model/crud.py
@@ -415,3 +415,13 @@ async def count_logs_by_date(session: Session | AsyncSession, election_id: int, 
              models.ElectionLog.created_at <= end_date))
     result = await db_handler.execute(session, query)
     return result.all()
+
+
+async def get_logs_by_type(session: Session | AsyncSession, election_id: int, type_log):
+
+    query = select(models.ElectionLog.created_at, models.ElectionLog.event_params).where(
+        models.ElectionLog.election_id == election_id,
+        models.ElectionLog.event == type_log,
+    )
+    result = await db_handler.execute(session, query)
+    return result.all()

--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -16,6 +16,7 @@ from sqlalchemy.types import Boolean, Integer, String, Text, Enum, DateTime
 
 from app.psifos import utils
 from app.psifos.psifos_object.questions import Questions
+from app.psifos.psifos_object.result import ElectionResult
 
 import app.psifos.crypto.utils as crypto_utils
 from datetime import datetime
@@ -172,6 +173,21 @@ class Election(Base):
                 partial_decryptions=partial_decryptions,
                 election=self
             ),
+            "election_status": ElectionStatusEnum.decryptions_combined,
+        }
+
+    def end_without_votes(self):
+        question_list = Questions.serialize(self.questions, to_json=False)
+        results = []
+        for question in question_list:
+            results.append({
+                "tally_type": question["tally_type"],
+                "ans_results": ["0"] * int(question["total_closed_options"])
+            })
+
+        election_result = ElectionResult(*results)
+        return {
+            "result": election_result,
             "election_status": ElectionStatusEnum.decryptions_combined,
         }
 

--- a/app/psifos_auth/auth_service_logging.py
+++ b/app/psifos_auth/auth_service_logging.py
@@ -78,10 +78,10 @@ class AbstractAuth(object):
 
         
         if (voter is not None) or (not election.private_p):
-            await psifos_logger.info(election_id=election.id, event=ElectionAdminEventEnum.VOTER_LOGIN)
+            await psifos_logger.info(election_id=election.id, event=ElectionAdminEventEnum.VOTER_LOGIN, user=user_id)
 
         else:
-            await psifos_logger.info(election_id=election.id, event=ElectionAdminEventEnum.VOTER_LOGIN_FAIL)
+            await psifos_logger.info(election_id=election.id, event=ElectionAdminEventEnum.VOTER_LOGIN_FAIL, user=user_id)
 
         return RedirectResponse(
                 url=APP_FRONTEND_URL + "psifos/booth/" + short_name


### PR DESCRIPTION
## Titulo
Ruta de admin para ingresos fallidos y cerrar elecciones sin votos

## Descripción
- Se crea una ruta en el administrador para ver cuales votantes ingresaron de manera incorrecta en una elección, junto a la fecha en la que ocurrió el evento.
- Ahora las elecciones se logran cerrar cuando no existen votos disponibles, saltándose la parte matemática y pasa directamente a los resultados.

## Como probar
- Ir a los docs de la pagina de fast api (copiar token bear y pegarlo) o crear un script en python junto a la ruta `/{short_name}/logs/invalid-voters-logging` y este devuelve un json de los usuarios.
- Generar una elección normalmente, no votar y cerrarla. Esta calculara el resultado directamente saltándose la parte matemática del Tally