### PR TITLE
FEAT create ranking questions

### DIFF
--- a/app/psifos/psifos_object/questions.py
+++ b/app/psifos/psifos_object/questions.py
@@ -16,13 +16,15 @@ class QuestionFactory():
 
     @staticmethod
     def create(**kwargs):
+        q_type_list = {
+            "closed_question": ClosedQuestion,
+            "mixnet_question": MixnetQuestion,
+            "stvnc_question": STVNCQuestion,
+        }
         q_type = kwargs.get("q_type", None)
-        if q_type == "closed_question":
-            return ClosedQuestion(**kwargs)
-        elif q_type == "mixnet_question":
-            return MixnetQuestion(**kwargs)
-        else:
-            return None
+        if q_type in q_type_list.keys():
+            return q_type_list[q_type](**kwargs)
+        return None
 
 
 class Questions(SerializableList):
@@ -82,3 +84,13 @@ class MixnetQuestion(AbstractQuestion):
         super(MixnetQuestion, self).__init__(**kwargs)
         self.tally_type = "mixnet"
         self.group_votes: str = str(kwargs["group_votes"])
+
+class STVNCQuestion(AbstractQuestion):
+    """
+    Allows a voter to select a permutation of options.
+    Is the no coersion case.
+    """
+
+    def __init__(self, **kwargs) -> None:
+        super(STVNCQuestion, self).__init__(**kwargs)
+        self.tally_type = "stvnc"     


### PR DESCRIPTION
# Objetivo
Poder almacenar en la bdd elecciones con ranking preferencial (hasta el momento en un escenario sin coerción).

# Resultado
Al crear una pregunta con ranking desde el front, se almacena en la bdd la información de pregunta para elección correspondiente.
<img width="988" alt="Captura de Pantalla 2023-08-23 a la(s) 21 50 34" src="https://github.com/clcert/psifos-backend-op/assets/53621395/1358c3d6-be37-46d7-a315-912ec300f3a8">

# Dependencias
Para testear es necesario esta en la siguiente rama del front
- https://github.com/clcert/psifos-frontend/pull/53

# Testing
Crear una elección con una pregunta de tipo "Pregunta con ranking preferencial" en el formulario de creación de preguntas, tal como lo muestra la imagen.
![Captura de Pantalla 2023-08-23 a la(s) 21 52 29](https://github.com/clcert/psifos-backend-op/assets/53621395/69d6d401-27ef-44db-a998-58b4daade587)
Observar en la bdd la tabla `psifos_election`, para la fila correspondiente a la elección en cuestión la columna `questions`.