### PR TITLE
add result release route

### DIFF
--- a/app/psifos/model/enums.py
+++ b/app/psifos/model/enums.py
@@ -39,6 +39,7 @@ class ElectionPublicEventEnum(ElectionEventEnum):
     TALLY_COMPUTED = "tally_computed"
     DECRYPTION_RECIEVED = "decryption_recieved"
     DECRYPTIONS_COMBINED = "decryptions_combined"
+    RESULTS_RELEASED = "results_released"
 
 
 class ElectionAdminEventEnum(ElectionEventEnum):

--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -190,6 +190,12 @@ class Election(Base):
             "result": election_result,
             "election_status": ElectionStatusEnum.decryptions_combined,
         }
+    
+    def results_released(self):
+        released_data = {
+            "election_status": ElectionStatusEnum.results_released,
+        }
+        return released_data
 
     def voting_has_started(self):
         return True if self.voting_started_at is not None else False

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -459,6 +459,31 @@ async def combine_decryptions(
     }
 
 
+@api_router.post("/{short_name}/results-release", status_code=200)
+async def results_release(
+    short_name: str,
+    current_user: models.User = Depends(AuthAdmin()),
+    session: Session | AsyncSession = Depends(get_session),
+):
+    """
+    Route for release results
+    """
+    election = await get_auth_election(
+        short_name=short_name,
+        current_user=current_user,
+        session=session,
+        status=ElectionStatusEnum.decryptions_combined
+    )
+    await crud.update_election(
+        session=session, election_id=election.id, fields=election.results_released()
+    )
+
+    await psifos_logger.info(
+        election_id=election.id, event=ElectionPublicEventEnum.RESULTS_RELEASED
+    )
+
+    return {"message": "The election has released the results"}
+
 @api_router.get(
     "/{short_name}/get-trustees",
     status_code=200,


### PR DESCRIPTION
## Titulo
Estado de resultados liberados

## Descripción
Se agrega un nuevo estado a las elecciones que corresponde a la acción de liberar los resultados, ahora cuando se combinan las desencriptaciones parciales se genera un nuevo paso manual para que los resultados sean liberados al publico.