### PR TITLE
FEAT STV sin coersión

### DIFF
--- a/app/psifos/crypto/tally/common/encrypted_answer/enc_ans_factory.py
+++ b/app/psifos/crypto/tally/common/encrypted_answer/enc_ans_factory.py
@@ -1,16 +1,17 @@
 from app.psifos.crypto.tally.homomorphic.encrypted_answer import EncryptedClosedAnswer
-from app.psifos.crypto.tally.mixnet.encrypted_answer import EncryptedOpenAnswer, EncryptedMixnetAnswer
+from app.psifos.crypto.tally.mixnet.encrypted_answer import EncryptedOpenAnswer, EncryptedMixnetAnswer, EncryptedStvncAnswer
 from app.database.serialization import SerializableObject
 
 
 class EncryptedAnswerFactory(SerializableObject):
     def create(**kwargs):
+        enc_ans_types = {
+            "encrypted_closed_answer": EncryptedClosedAnswer,
+            "encrypted_open_answer": EncryptedOpenAnswer,
+            "encrypted_mixnet_answer": EncryptedMixnetAnswer,
+            "encrypted_stvnc_answer": EncryptedStvncAnswer,
+        }
         q_type = kwargs.get("enc_ans_type", None)
-        if q_type == "encrypted_closed_answer":
-            return EncryptedClosedAnswer(**kwargs)
-        elif q_type == "encrypted_open_answer":
-            return EncryptedOpenAnswer(**kwargs)
-        elif q_type == "encrypted_mixnet_answer":
-            return EncryptedMixnetAnswer(**kwargs)
-        else:
-            return None
+        if q_type in enc_ans_types.keys():
+            return enc_ans_types[q_type](**kwargs)
+        return None

--- a/app/psifos/crypto/tally/mixnet/encrypted_answer.py
+++ b/app/psifos/crypto/tally/mixnet/encrypted_answer.py
@@ -20,4 +20,14 @@ class EncryptedMixnetAnswer(AbstractEncryptedAnswer):
     
     def verify(self, **kwargs):
         return len(self.get_choices()) == MIXNET_WIDTH
+
+class EncryptedStvncAnswer(AbstractEncryptedAnswer):
+    """
+    An encrypted mixnet answer to a single election question.
+    """
+    def __init__(self, **kwargs) -> None:
+        super(EncryptedStvncAnswer, self).__init__(**kwargs)
+    
+    def verify(self, **kwargs):
+        return len(self.get_choices()) == MIXNET_WIDTH
     

--- a/app/psifos/crypto/tally/tally.py
+++ b/app/psifos/crypto/tally/tally.py
@@ -10,11 +10,14 @@ from .mixnet.tally import MixnetTally
 class TallyFactory():
     @staticmethod
     def create(**kwargs):
+        tally_to_mn_tally = {
+            "homomorphic":HomomorphicTally,
+            "mixnet":MixnetTally,
+            "stvnc":MixnetTally,
+        }
         tally_type = kwargs.get("tally_type")
-        if tally_type == "homomorphic":
-            return HomomorphicTally(**kwargs)
-        elif tally_type == "mixnet":
-            return MixnetTally(**kwargs)
+        if tally_type in tally_to_mn_tally.keys():
+            return tally_to_mn_tally[tally_type](**kwargs)
           
 class TallyManager(SerializableList):
     """

--- a/app/psifos/psifos_object/questions.py
+++ b/app/psifos/psifos_object/questions.py
@@ -93,4 +93,4 @@ class STVNCQuestion(AbstractQuestion):
 
     def __init__(self, **kwargs) -> None:
         super(STVNCQuestion, self).__init__(**kwargs)
-        self.tally_type = "stvnc"     
+        self.tally_type = "stvnc"


### PR DESCRIPTION
# Objetivo
Recibir desde el front respuestas a preguntas con ranking preferencial.

# Estrategia
Copiar el proceso que siguen las preguntas con mn, calculando el resultado de la misma manera.

# Resultado
Las respuestas con ranking preferencial existen de manera separada, pero imitan el comportamiento de las preguntas con mn.
Solo falta agregar al proceso un paso en el que, después de desencriptar los votos, se aplica el algoritmo de STV.
Una vez hecho lo anterior, se terminaría de replicar el modelo descrito en el [siguiente documento](https://docs.google.com/document/d/1cFzRh0LOPlr3Xc4GTeBQbYZ0ypXk1SIMpVF7ki5MXxY/edit?usp=drive_web&ouid=100642406970855857357).