### PR TITLE
FEAT Algoritmo STV sin coerción

### DIFF
--- a/app/psifos/crypto/tally/mixnet/close_massive_tally.py
+++ b/app/psifos/crypto/tally/mixnet/close_massive_tally.py
@@ -1,0 +1,33 @@
+"""
+Mixnet tally for close massive psifos questions.
+
+14-09-2023
+"""
+
+from app.psifos.crypto.tally.mixnet.tally import MixnetTally
+
+class CloseMassiveTally(MixnetTally):
+    def count_votes(self, votes, total_closed_options):
+        # The votes come with a +1 from the front, take it into account when counting
+        q_result = [0] * total_closed_options
+        null_vote = total_closed_options + 1
+        blank_vote = null_vote - 1
+
+        # Lets count by votes
+        for vote in votes:
+            set_vote = set(vote)
+
+            # check null vote
+            if null_vote in vote:
+                q_result[null_vote - 2] += 1
+
+            # check blank vote
+            elif len(set_vote) == 1 and blank_vote in set_vote:
+                q_result[blank_vote - 2] += 1
+
+            # count normal counts
+            else:   
+                for answer in vote:
+                    q_result[answer - 1] += 1 if answer != blank_vote else 0
+
+        return q_result

--- a/app/psifos/crypto/tally/mixnet/stv_tally.py
+++ b/app/psifos/crypto/tally/mixnet/stv_tally.py
@@ -1,0 +1,23 @@
+"""
+Mixnet tally for STV psifos questions.
+
+14-09-2023
+"""
+
+from app.psifos.crypto.tally.mixnet.tally import MixnetTally
+from stvpoll.scottish_stv import ScottishSTV
+
+class STVTally(MixnetTally):
+    def count_votes(self, votes, total_closed_options):
+        # STV questions doesn't include blank and null options
+        control_vote = votes[0]
+        if (total_closed_options == len(control_vote)):
+            poll = ScottishSTV(seats=1, candidates=sorted(votes[0]))
+
+            # Add each vote to the poll
+            for vote in votes:
+                poll.add_ballot(vote, 1)
+
+            # Calculates the result
+            result = list(poll.calculate())
+            return result

--- a/app/psifos/crypto/tally/mixnet/tally.py
+++ b/app/psifos/crypto/tally/mixnet/tally.py
@@ -1,7 +1,7 @@
 """
 Mixnet tally for psifos questions.
 
-27-05-2022
+14-09-2023
 """
 
 import itertools
@@ -119,29 +119,3 @@ class MixnetTally(AbstractTally):
         }
 
         return result
-
-    def count_votes(self, votes, total_closed_options):
-
-        # The votes come with a +1 from the front, take it into account when counting
-        q_result = [0] * total_closed_options
-        null_vote = total_closed_options + 1
-        blank_vote = null_vote - 1
-
-        # Lets count by votes
-        for vote in votes:
-            set_vote = set(vote)
-
-            # check null vote
-            if null_vote in vote:
-                q_result[null_vote - 2] += 1
-
-            # check blank vote
-            elif len(set_vote) == 1 and blank_vote in set_vote:
-                q_result[blank_vote - 2] += 1
-
-            # count normal counts
-            else:   
-                for answer in vote:
-                    q_result[answer - 1] += 1 if answer != blank_vote else 0
-
-        return q_result

--- a/app/psifos/crypto/tally/tally.py
+++ b/app/psifos/crypto/tally/tally.py
@@ -5,15 +5,16 @@ Tally module for Psifos.
 from app.database.serialization import SerializableList
 from app.psifos.psifos_object.result import ElectionResult
 from .homomorphic.tally import HomomorphicTally
-from .mixnet.tally import MixnetTally
+from .mixnet.close_massive_tally import CloseMassiveTally
+from .mixnet.stv_tally import STVTally
 
 class TallyFactory():
     @staticmethod
     def create(**kwargs):
         tally_to_mn_tally = {
             "homomorphic":HomomorphicTally,
-            "mixnet":MixnetTally,
-            "stvnc":MixnetTally,
+            "mixnet":CloseMassiveTally,
+            "stvnc":STVTally,
         }
         tally_type = kwargs.get("tally_type")
         if tally_type in tally_to_mn_tally.keys():

--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ sniffio==1.3.0
 SQLAlchemy==1.4.40
 starlette==0.27.0
 starlette-context==0.3.4
+STVPoll==0.4.5
 toml==0.10.2
 tomli==2.0.1
 tornado==6.3.3


### PR DESCRIPTION
# Objetivo
En el conteo de una pregunta con ranking, en específico STV escenario sin coerción, se debe incorporar el algoritmo STV en el conteo, tal como se propone en el siguiente [documento](https://docs.google.com/document/d/1cFzRh0LOPlr3Xc4GTeBQbYZ0ypXk1SIMpVF7ki5MXxY/edit?usp=sharing).

# Estrategia

# Resultado
