### PR TITLE
Tamaño dinámico en la mixnet

### DIFF
--- a/app/psifos/crypto/tally/mixnet/encrypted_answer.py
+++ b/app/psifos/crypto/tally/mixnet/encrypted_answer.py
@@ -19,7 +19,8 @@ class EncryptedMixnetAnswer(AbstractEncryptedAnswer):
         super(EncryptedMixnetAnswer, self).__init__(**kwargs)
     
     def verify(self, **kwargs):
-        return len(self.get_choices()) == MIXNET_WIDTH
+        max_ptxt = kwargs.get('max_ptxt')
+        return len(self.get_choices()) == max_ptxt
 
 class EncryptedStvncAnswer(AbstractEncryptedAnswer):
     """

--- a/app/psifos/crypto/tally/mixnet/tally.py
+++ b/app/psifos/crypto/tally/mixnet/tally.py
@@ -46,11 +46,18 @@ class MixnetTally(AbstractTally):
         election = kwargs.get("election")
         election_name = election.short_name
         election_uuid = election.uuid
-        
+
+        mixnet_width = kwargs.get("width")
         server_names = [MIXNET_01_NAME, MIXNET_02_NAME, MIXNET_03_NAME]
         server_urls = [MIXNET_01_URL, MIXNET_02_URL, MIXNET_03_URL]
 
         TOKEN = re.sub(r'[^a-zA-Z0-9]+', '', f'{election_name}{election_uuid}{time.time()}')
+
+        for name, url in zip(server_names, server_urls):
+            requests.post(url=f"{url}/configure-mixnet", json={
+                'mixnet_width': mixnet_width,
+                'token' : TOKEN
+            })
 
         # then we create the payload and send it to each mixnet sv
         for name, url in zip(server_names, server_urls):

--- a/app/psifos/crypto/tally/tally.py
+++ b/app/psifos/crypto/tally/tally.py
@@ -66,12 +66,13 @@ class TallyWrapper(SerializableObject):
             encrypted_answers = [
                 enc_vote.answers.instances[q_num] for enc_vote in encrypted_votes
             ]
-
+            width = election.questions.instances[q_num].max_answers
             tally.compute(
                 public_key=public_key,
                 encrypted_answers=encrypted_answers,
                 weights=weights,
                 election=election,
+                width=width
             )
 
     def decrypt(self, partial_decryptions, election, group):


### PR DESCRIPTION
##
Tamaño dinámico en la mixnet

## Descripción
La idea principal es configurar la mixnet con el tamaño adecuado dependiendo la pregunta 

## Como probar
Crear una elección con un tamaño distinto de 6 en la mixnet y computar el tally