### PR TITLE
feat: saves stv options detail

### DIFF
--- a/app/psifos/model/schemas.py
+++ b/app/psifos/model/schemas.py
@@ -231,6 +231,7 @@ class BoothElectionOut(PsifosSchema):
     public_key: object | None
     questions: object | None
     uuid: str | None
+    name: str | None
     class Config:
         orm_mode = True
 

--- a/app/psifos/psifos_object/questions.py
+++ b/app/psifos/psifos_object/questions.py
@@ -59,6 +59,9 @@ class AbstractQuestion(SerializableObject):
         self.total_options: int = int(kwargs["total_options"])
         self.total_closed_options: int = int(kwargs["total_closed_options"])
         self.closed_options: list = kwargs["closed_options"]
+        self.options_specifications: list = (
+            kwargs["options_specifications"] if "options_specifications" in kwargs.keys() else 0
+        )
 
         self.max_answers: int = int(kwargs["max_answers"])
         self.min_answers: int = int(kwargs["min_answers"])

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -1251,7 +1251,8 @@ async def get_questions(
             models.Election.short_name,
             models.Election.questions,
             models.Election.public_key,
-            models.Election.uuid
+            models.Election.uuid,
+            models.Election.name
         ]
 
         _, election = await get_auth_voter_and_election(


### PR DESCRIPTION
# Objetivo
Almacenar información descriptiva de las opciones de una pregunta en votación con ranking.

# Estrategia
Agregar una sección para almacenar una imagen asociada a cada opción.

# Dependencias
- https://github.com/clcert/psifos-frontend/pull/211

# Testing
- Crear una pregunta de cualquier tipo y ver el campo options_specification en la tabla psifos_election de la bdd.

# Resultado
<img width="686" alt="Captura de Pantalla 2024-09-27 a la(s) 02 22 53" src="https://github.com/user-attachments/assets/65ea4644-9965-4022-9dd9-9d213045f026">
<img width="806" alt="Captura de Pantalla 2024-09-27 a la(s) 02 23 57" src="https://github.com/user-attachments/assets/2dfbbbda-ead0-4acd-8cc3-2e0a72009ab0">
