### PR TITLE
session server side

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -37,6 +37,8 @@ OAUTH_CLIENT_ID = os.environ.get("OAUTH_CLIENT_ID")
 OAUTH_CLIENT_SECRET = os.environ.get("OAUTH_CLIENT_SECRET")
 OAUTH_USER_INFO_URL = os.environ.get("OAUTH_USER_INFO_URL")
 
+ENCRYPTION_KEY = os.environ.get("ENCRYPTION_KEY")
+
 USE_ASYNC_ENGINE = bool(int(os.environ.get("USE_ASYNC_ENGINE", False)))
 CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
 CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND")

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -38,6 +38,7 @@ from app.psifos_auth.utils import (
     get_auth_voter_and_election,
 )
 from app.psifos_auth.auth_service_check import AuthUser
+from app.psifos_auth.redis_store import get_session_data
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from datetime import timedelta
@@ -901,7 +902,9 @@ async def get_trustee_panel(
     Trustee's route for getting his home
     """
 
-    username = request.session.get("user", None)
+    session_id = request.session.get("session_id")
+    session_data = await get_session_data(session_id)
+    username = session_data.get("user")
     if not username:
         raise HTTPException(status_code=400, detail="Custodio sin elecciones")
     trustee = await crud.get_trustee_by_username(session=session, username=username)

--- a/app/psifos_auth/auth_service_check.py
+++ b/app/psifos_auth/auth_service_check.py
@@ -79,7 +79,7 @@ class AuthOauthCheck(AuthServiceCheck):
     """
 
 
-    async def get_login_idget_login_id(self, request: Request):
+    async def get_login_id(self, request: Request):
 
         session_id = request.session.get("session_id", None)
         if not session_id:

--- a/app/psifos_auth/auth_service_check.py
+++ b/app/psifos_auth/auth_service_check.py
@@ -1,6 +1,8 @@
 from fastapi import Request, HTTPException
 from app.config import TYPE_AUTH
 
+from app.psifos_auth.redis_store import get_session_data
+
 
 class AuthUser:
     """
@@ -22,9 +24,9 @@ class AuthUser:
         if public_election:
             return request.session.get("user", None)
         if self.type_auth == "cas":
-            return self.cas.get_login_id(request)
+            return await self.cas.get_login_id(request)
         elif self.type_auth == "oauth":
-            return self.oauth.get_login_id(request)
+            return await self.oauth.get_login_id(request)
 
 
 
@@ -57,9 +59,12 @@ class AuthCasCheck(AuthServiceCheck):
     """
 
 
-    def get_login_id(self, request: Request):
-
-        user = request.session.get("user", None)
+    async def get_login_id(self, request: Request):
+        session_id = request.session.get("session_id", None)
+        if not session_id:
+            raise HTTPException(status_code=401, detail="unauthorized")
+        session_data = await get_session_data(session_id)
+        user = session_data.get("user", None)
         if not user:
             raise HTTPException(status_code=401, detail="unauthorized voter")
 
@@ -74,10 +79,14 @@ class AuthOauthCheck(AuthServiceCheck):
     """
 
 
-    def get_login_id(self, request: Request):
+    async def get_login_idget_login_id(self, request: Request):
 
-        user = request.session.get("user", None)
-        if not user or 'oauth_state' not in request.session:
+        session_id = request.session.get("session_id", None)
+        if not session_id:
+            raise HTTPException(status_code=401, detail="unauthorized")
+        session_data = await get_session_data(session_id)
+        user = session_data.get("user", None)
+        if not user or 'oauth_state' not in session_data:
             raise HTTPException(status_code=401, detail="unauthorized voter")
 
         return self.get_user_without_domain(user)

--- a/app/psifos_auth/auth_service_logging.py
+++ b/app/psifos_auth/auth_service_logging.py
@@ -77,11 +77,12 @@ class AbstractAuth(object):
                 event=ElectionAdminEventEnum.TRUSTEE_LOGIN,
                 user=request.session["user"],
             )
+            request.session["oauth_token"] = ""
             return RedirectResponse(
                 APP_FRONTEND_URL + f"psifos/{short_name}/trustee/{trustee.uuid}/home",
             )
 
-    async def check_voter(self, db_session, short_name: str, user_id: str):
+    async def check_voter(self, db_session, short_name: str, user_id: str, request: Request):
         """
         Check if the voter that logs in exists and redirects
         """
@@ -113,7 +114,7 @@ class AbstractAuth(object):
                 event=ElectionAdminEventEnum.VOTER_LOGIN_FAIL,
                 user=user_id,
             )
-
+        request.session["oauth_token"] = ""
         return RedirectResponse(url=APP_FRONTEND_URL + "psifos/booth/" + short_name)
 
 
@@ -317,11 +318,13 @@ class OAuth2Auth(AbstractAuth):
             user = user.get("email", "")
         else:
             user = user["fields"]["username"]
-
+            #user = user["preferred_username"]
+        del request.session["oauth_state"]
         request.session["user"] = user
 
         if request.session["type_logout"] == "voter":
-            return await self.check_voter(db_session, short_name, user)
+            # return await self.check_voter(db_session, short_name, user)
+            return await self.check_voter(db_session, short_name, user, request)
 
         elif request.session["type_logout"] == "trustee" and not isPanel:
             return await self.check_trustee(db_session, short_name, request)

--- a/app/psifos_auth/auth_service_logging.py
+++ b/app/psifos_auth/auth_service_logging.py
@@ -20,6 +20,8 @@ from starlette.responses import RedirectResponse
 from app.logger import psifos_logger, logger
 from app.psifos.model.enums import ElectionAdminEventEnum, ElectionLoginTypeEnum
 
+from app.psifos_auth.redis_store import store_session_data, get_session_data, delete_session_data, generate_session_id
+
 
 class AuthFactory:
     @staticmethod
@@ -77,7 +79,6 @@ class AbstractAuth(object):
                 event=ElectionAdminEventEnum.TRUSTEE_LOGIN,
                 user=request.session["user"],
             )
-            request.session["oauth_token"] = ""
             return RedirectResponse(
                 APP_FRONTEND_URL + f"psifos/{short_name}/trustee/{trustee.uuid}/home",
             )
@@ -252,56 +253,42 @@ class OAuth2Auth(AbstractAuth):
         )
         self.short_name = ""
         self.type_logout = ""
+        self.home_pages = {
+            "voter": APP_FRONTEND_URL + "psifos/booth/",
+            "trustee": APP_FRONTEND_URL + "psifos/trustee/",
+        }
 
-    @db_handler.method_with_session
-    async def login_voter(
-        self, db_session, short_name: str, request: Request = None, session: str = None
-    ):
-        request.session["short_name"] = short_name
-        request.session["type_logout"] = "voter"
+    async def login(self, short_name: str = None, user_type: str = None, request: Request = None, panel: bool = False):
+        session_id = generate_session_id()
+        request.session["session_id"] = session_id
         client = OAuth2Session(
             client_id=self.client_id,
             redirect_uri=APP_BACKEND_OP_URL + "authorized",
             scope=self.scope,
         )
-
         authorization_url, state = client.authorization_url(OAUTH_AUTHORIZE_URL)
-        request.session["oauth_state"] = state
+        await store_session_data(session_id, {"short_name": short_name, "type_logout": user_type, "oauth_state": state, "panel": panel}, expires_in=3600)
         return RedirectResponse(authorization_url)
-
-    def logout_voter(self, short_name: str, request: Request):
-        pass
+    
+    async def logout(self, user_type: str, request: Request):
+        session_id = request.session.get("session_id")
+        await delete_session_data(session_id)
+        request.session.clear()
+        return RedirectResponse(url=self.home_pages[user_type])
 
     @db_handler.method_with_session
-    async def login_trustee(
-        self, db_session, request: Request, session: str, panel: bool = False, short_name: str = None
-    ):
-        request.session["short_name"] = short_name
-        request.session["type_logout"] = "trustee"
-        request.session["panel"] = panel
+    async def authorized(self, db_session, request: Request):
+        session_id = request.session.get("session_id")
+        if not session_id:
+            raise HTTPException(status_code=400, detail="Sesión no encontrada.")
 
-        self.type_logout = "trustee"
-        client = OAuth2Session(
-            client_id=self.client_id,
-            redirect_uri=APP_BACKEND_OP_URL + "authorized",
-            scope=self.scope,
-        )
+        session_data = await get_session_data(session_id)
+        if not session_data:
+            raise HTTPException(status_code=400, detail="Datos de sesión no válidos.")
 
-        authorization_url, state = client.authorization_url(OAUTH_AUTHORIZE_URL)
-        request.session["oauth_state"] = state
-
-        return RedirectResponse(authorization_url)
-
-    def logout_trustee(self, short_name: str, request: Request):
-        pass
-
-    @db_handler.method_with_session
-    async def authorized(self, db_session, request: Request, session: str = None):
-        short_name = request.session["short_name"]
-        isPanel = request.session.get("panel", False)
         login = OAuth2Session(
             self.client_id,
-            state=request.session["oauth_state"],
+            state=session_data["oauth_state"],
             redirect_uri=APP_BACKEND_OP_URL + "authorized",
         )
         resp = login.fetch_token(
@@ -309,9 +296,9 @@ class OAuth2Auth(AbstractAuth):
             client_secret=self.client_secret,
             authorization_response=str(request.url),
         )
-        request.session["oauth_token"] = resp
+        session_data["oauth_token"] = resp
 
-        login = OAuth2Session(OAUTH_CLIENT_ID, token=request.session["oauth_token"])
+        login = OAuth2Session(OAUTH_CLIENT_ID, token=session_data["oauth_token"])
         user = login.get(OAUTH_USER_INFO_URL).json()
 
         if OAUTH_GOOGLE:
@@ -319,17 +306,17 @@ class OAuth2Auth(AbstractAuth):
         else:
             user = user["fields"]["username"]
             #user = user["preferred_username"]
-        del request.session["oauth_state"]
-        request.session["user"] = user
+        session_data["user"] = user
+        await store_session_data(session_id, session_data, expires_in=3600)
 
-        if request.session["type_logout"] == "voter":
+        if session_data["type_logout"] == "voter":
             # return await self.check_voter(db_session, short_name, user)
-            return await self.check_voter(db_session, short_name, user, request)
+            return await self.check_voter(db_session, session_data["short_name"], user, request)
 
-        elif request.session["type_logout"] == "trustee" and not isPanel:
-            return await self.check_trustee(db_session, short_name, request)
+        elif session_data["type_logout"] == "trustee" and not session_data["panel"]:
+            return await self.check_trustee(db_session, session_data["short_name"], request)
         
-        elif isPanel:
+        elif session_data["panel"]:
             trustee_params = [crud.models.Trustee.id]
             trustee = await crud.get_trustee_params_by_username(session=db_session, username=user, params=trustee_params)
             if trustee:

--- a/app/psifos_auth/auth_service_logging.py
+++ b/app/psifos_auth/auth_service_logging.py
@@ -115,7 +115,6 @@ class AbstractAuth(object):
                 event=ElectionAdminEventEnum.VOTER_LOGIN_FAIL,
                 user=user_id,
             )
-        request.session["oauth_token"] = ""
         return RedirectResponse(url=APP_FRONTEND_URL + "psifos/booth/" + short_name)
 
 

--- a/app/psifos_auth/redis_store.py
+++ b/app/psifos_auth/redis_store.py
@@ -1,0 +1,34 @@
+import redis.asyncio as redis
+import json
+
+from cryptography.fernet import Fernet
+from uuid import uuid4
+
+from app.config import ENCRYPTION_KEY
+
+# Configuración de Redis
+redis_client = redis.Redis(host='redis', port=6379, db=0)
+# Configuración de cifrado
+cipher_suite = Fernet(ENCRYPTION_KEY)
+
+def generate_session_id():
+    """Genera un ID de sesión único."""
+    return str(uuid4())
+
+async def store_session_data(session_id: str, data: dict, expires_in: int = 3600):
+    """Almacena datos de sesión en Redis con cifrado."""
+    serialized_data = json.dumps(data)
+    encrypted_data = cipher_suite.encrypt(serialized_data.encode())
+    await redis_client.setex(f"session:{session_id}", expires_in, encrypted_data)
+
+async def get_session_data(session_id: str):
+    """Recupera y descifra datos de sesión desde Redis."""
+    encrypted_data = await redis_client.get(f"session:{session_id}")
+    if encrypted_data:
+        decrypted_data = cipher_suite.decrypt(encrypted_data).decode()
+        return json.loads(decrypted_data)
+    return None
+
+async def delete_session_data(session_id: str):
+    """Elimina datos de sesión de Redis."""
+    await redis_client.delete(f"session:{session_id}")

--- a/app/psifos_auth/routes.py
+++ b/app/psifos_auth/routes.py
@@ -69,17 +69,17 @@ async def login_voter(short_name: str, request: Request, redirect: bool = Query(
         return RedirectResponse(url=APP_FRONTEND_URL + "psifos/booth/" + short_name) if redirect else {"message": "success"}
 
     auth = auth_factory.get_auth(protocol)
-    return await auth.login_voter(short_name=short_name, request=request, session=session_cookie)
+    return await auth.login(short_name=short_name, user_type="voter", request=request)
 
 
 @auth_router.get("/vote/{short_name}/logout", status_code=200)
-async def logout_voter(short_name: str, request: Request):
+async def logout_voter(request: Request):
     """
     Logout a user
     """
 
     auth = auth_factory.get_auth(protocol)
-    return auth.logout_voter(short_name, request)
+    return auth.logout(user_type="voter", request=request)
 
 
 # Trustee Auth
@@ -92,31 +92,31 @@ async def login_trustee(short_name: str, request: Request, session_cookie: str |
     """
     
     auth = auth_factory.get_auth(protocol)
-    return await auth.login_trustee(short_name=short_name, request=request, session=session_cookie)
+    return await auth.login(short_name=short_name, user_type="trustee", request=request)
 
 @auth_router.get("/trustee/login/panel", status_code=200)
-async def login_trustee_panel(request: Request, session_cookie: str | None = Cookie(default=None)):
+async def login_trustee_panel(request: Request):
     """
     Make the connection and verification with the CAS service
     """
     
     auth = auth_factory.get_auth(protocol)
-    return await auth.login_trustee(request=request, session=session_cookie, panel=True)
+    return await auth.login(request=request, user_type="trustee", panel=True)
 
 
 @auth_router.get("/{short_name}/trustee/logout", status_code=200)
-async def logout_trustee(short_name: str, request: Request):
+async def logout_trustee(request: Request):
     """
     Logout a trustee
     """
     auth = auth_factory.get_auth(protocol)
-    return auth.logout_trustee(short_name, request)
+    return auth.logout(user_type="trustee", request=request)
 
 
 # OAuth2
 
 @auth_router.get("/authorized", status_code=200)
-async def authorized(request: Request, session_cookie: str | None = Cookie(default=None)):
+async def authorized(request: Request):
 
     auth = auth_factory.get_auth(protocol)
-    return await auth.authorized(request, session=session_cookie)
+    return await auth.authorized(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,3 +87,4 @@ fastapi-analytics==1.1.4
 loguru==0.7.2
 gunicorn==22.0.0
 pyinstrument==5.0.0
+cryptography==44.0.2


### PR DESCRIPTION
## Título  
Manejo de sesiones en el servidor  

## Descripción  
Actualmente, utilizamos la cookie de sesión proporcionada por **FastAPI** para gestionar las sesiones en la aplicación. Sin embargo, el usuario recibe y almacena todos los valores de sesión, enviándolos cuando es necesario. Esto puede generar vulnerabilidades, como sesiones falsas.  

Con esta nueva funcionalidad, el usuario solo almacenará un **ID de sesión**, mientras que los datos importantes se guardarán **encriptados en Redis** y se desencriptarán cuando sea necesario. Esto mejora significativamente la seguridad de la aplicación.  

## Cómo probar  
Probar las sesiones de **votantes** y **custodios**.