### PR TITLE
deliver eg params accordingly to first question tally type

### DIFF
--- a/app/psifos/model/models.py
+++ b/app/psifos/model/models.py
@@ -95,7 +95,7 @@ class Election(Base):
     def total_questions(self):
         return len(self.questions)
 
-    def get_eg_params(self, serialize=True):
+    def get_eg_params(self, tally_type="", serialize=True):
         """
         Returns the current election params for elgamal encryption.
 
@@ -119,14 +119,27 @@ class Election(Base):
             t=self.total_trustees // 2,
         )
 
-        params = {
-            "homomorphic_params": ElGamal.serialize(homomorphic_params)
-            if serialize
-            else homomorphic_params,
-            "mixnet_params": ElGamal.serialize(mixnet_params)
-            if serialize
-            else mixnet_params,
-        }
+        if tally_type == "":
+            params = {
+                "homomorphic_params": ElGamal.serialize(homomorphic_params)
+                if serialize
+                else homomorphic_params,
+                "mixnet_params": ElGamal.serialize(mixnet_params)
+                if serialize
+                else mixnet_params,
+            }
+        elif tally_type == "homomorphic":
+            params = {
+                "params": ElGamal.serialize(homomorphic_params)
+                if serialize
+                else homomorphic_params
+            }
+        else: # mixnet
+            params = {
+                "params": ElGamal.serialize(mixnet_params)
+                if serialize
+                else mixnet_params,
+            }
 
         return params
     

--- a/app/psifos/routes.py
+++ b/app/psifos/routes.py
@@ -1032,8 +1032,14 @@ async def election_get_eg_params(
         #     session=session, election_id=election.id
         # )
         # return election.get_eg_params(total_trustees=total_trustees)        
-        return election.get_eg_params()
-
+        questions = await crud.get_questions_by_election_id(
+            session=session, election_id=election.id
+        )
+        if questions[0].type == "CLOSED":
+            return election.get_eg_params("homomorphic")
+        else:
+            return election.get_eg_params("mixnet")
+        
     except Exception as e:
         print(e)
         raise HTTPException(


### PR DESCRIPTION
Only deliver correct eg-params accordingly to tally type of first question configured in the election.